### PR TITLE
Make WakaTime requests fail safely and follow the current API contract

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,46 +1,126 @@
 const https = require("https");
 
+const REQUEST_TIMEOUT_MS = 30000;
+
 module.exports = (apiKey) => ({
   last7Days: () => request(apiKey, "/users/current/stats/last_7_days"),
   last30Days: () => request(apiKey, "/users/current/stats/last_30_days"),
   last6Months: () => request(apiKey, "/users/current/stats/last_6_months"),
   lastYear: () => request(apiKey, "/users/current/stats/last_year"),
-  summaries: (start, end) => request(apiKey, `/users/current/summaries?start=${start}&end=${end}`),
+  summaries: (start, end) => request(apiKey, () => summariesResource(start, end)),
   currentUser: () => request(apiKey, "/users/current"),
 });
 
 function apiKeyBase64(apiKey) {
-  const apiKeyBuffer = Buffer.from(apiKey);
-  return apiKeyBuffer.toString("base64");
+  return Buffer.from(apiKey).toString("base64");
 }
 
-function request(apiKey, path) {
-  const options = {
-    port: 443,
-    hostname: "wakatime.com",
-    path: `/api/v1${path}`,
-    method: "GET",
-    headers: {
-      Authorization: `Basic ${apiKeyBase64(apiKey)}`,
-    },
-  };
+function summariesResource(start, end) {
+  validateDate("start", start);
+  validateDate("end", end);
+  if (start > end) {
+    throw new TypeError("start must be earlier than or equal to end");
+  }
+  return `/users/current/summaries?${new URLSearchParams({ start, end })}`;
+}
+
+function validateDate(name, value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new TypeError(`${name} must be a valid date in YYYY-MM-DD format`);
+  }
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new TypeError(`${name} must be a valid date in YYYY-MM-DD format`);
+  }
+}
+
+function request(apiKey, resourceValue) {
   return new Promise((resolve, reject) => {
-    let responseBody = "";
+    if (typeof apiKey !== "string" || apiKey.trim() === "") {
+      reject(new TypeError("apiKey must be a non-empty string"));
+      return;
+    }
+
+    let resource;
+    try {
+      resource = typeof resourceValue === "function" ? resourceValue() : resourceValue;
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const options = {
+      port: 443,
+      hostname: "api.wakatime.com",
+      path: `/api/v1${resource}`,
+      method: "GET",
+      headers: { Authorization: `Basic ${apiKeyBase64(apiKey)}` },
+    };
+
+    let settled = false;
+    const settle = (callback, value) => {
+      if (!settled) {
+        settled = true;
+        callback(value);
+      }
+    };
+    const fail = (error) => {
+      if (error && typeof error === "object" && !("resource" in error)) {
+        error.resource = resource;
+      }
+      settle(reject, error);
+    };
+
     const req = https.request(options, (res) => {
+      let responseBody = "";
       res.on("data", (data) => {
         responseBody += data;
       });
-
-      res.on("end", () => {
-        try {
-          const bodyJSON = JSON.parse(responseBody);
-          resolve(bodyJSON);
-        } catch (e) {
-          reject(e);
+      res.on("error", fail);
+      res.on("aborted", () => fail(new Error(`WakaTime API response aborted for ${resource}`)));
+      res.on("close", () => {
+        if (!res.complete) {
+          fail(new Error(`WakaTime API response closed before completion for ${resource}`));
         }
+      });
+      res.on("end", () => {
+        const statusCode = res.statusCode;
+        if (statusCode >= 200 && statusCode < 300) {
+          if (responseBody === "") {
+            fail(new SyntaxError(`WakaTime API returned an empty response for ${resource}`));
+            return;
+          }
+          try {
+            settle(resolve, JSON.parse(responseBody));
+          } catch (error) {
+            fail(error);
+          }
+          return;
+        }
+
+        const error = new Error(`WakaTime API request failed with status ${statusCode} for ${resource}`);
+        error.name = "WakaTimeApiError";
+        error.statusCode = statusCode;
+        error.resource = resource;
+        if (responseBody === "") {
+          error.body = null;
+        } else {
+          try {
+            error.body = JSON.parse(responseBody);
+          } catch (_error) {
+            error.body = responseBody;
+          }
+        }
+        fail(error);
       });
     });
 
+    req.on("error", fail);
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      const error = new Error(`WakaTime API request timed out after ${REQUEST_TIMEOUT_MS}ms for ${resource}`);
+      error.code = "ETIMEDOUT";
+      req.destroy(error);
+    });
     req.end();
   });
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,6 @@ const test = require("node:test");
 const https = require("https");
 
 const createWakaTime = require("..");
-
 const API_KEY = "test-api-key";
 const originalRequest = https.request;
 
@@ -13,33 +12,61 @@ test.afterEach(() => {
   https.request = originalRequest;
 });
 
-function stubRequest({ body = { data: { ok: true } }, malformed = false } = {}) {
+function stubRequest(scenario = {}) {
   const calls = [];
-
   https.request = (options, callback) => {
-    calls.push(options);
-
     const request = new EventEmitter();
+    let timeoutHandler;
+    calls.push({ options, request });
+    request.setTimeout = (timeout, handler) => {
+      request.timeout = timeout;
+      timeoutHandler = handler;
+    };
+    request.destroy = (error) => request.emit("error", error);
     request.end = () => {
       setImmediate(() => {
+        if (scenario.requestError) {
+          request.emit("error", scenario.requestError);
+          return;
+        }
+        if (scenario.timeout) {
+          timeoutHandler();
+          return;
+        }
         const response = new EventEmitter();
+        response.statusCode = scenario.statusCode === undefined ? 200 : scenario.statusCode;
+        response.complete = !scenario.prematureClose;
         callback(response);
-        response.emit("data", malformed ? "{" : JSON.stringify(body));
+        if (scenario.responseError) {
+          response.emit("error", scenario.responseError);
+          return;
+        }
+        if (scenario.aborted) {
+          response.complete = false;
+          response.emit("aborted");
+          response.emit("close");
+          return;
+        }
+        const body = Object.prototype.hasOwnProperty.call(scenario, "rawBody")
+          ? scenario.rawBody
+          : JSON.stringify(scenario.body === undefined ? { data: { ok: true } } : scenario.body);
+        if (body !== "") response.emit("data", body);
+        if (scenario.prematureClose) {
+          response.emit("close");
+          return;
+        }
         response.emit("end");
+        response.emit("close");
       });
     };
-
     return request;
   };
-
   return calls;
 }
 
-test("exports a CommonJS factory with the existing public methods", () => {
-  assert.equal(typeof createWakaTime, "function");
-
+test("exports the existing CommonJS public API", () => {
   const wakatime = createWakaTime(API_KEY);
-
+  assert.equal(typeof createWakaTime, "function");
   assert.deepEqual(Object.keys(wakatime).sort(), [
     "currentUser",
     "last30Days",
@@ -48,9 +75,6 @@ test("exports a CommonJS factory with the existing public methods", () => {
     "lastYear",
     "summaries",
   ]);
-  for (const method of Object.values(wakatime)) {
-    assert.equal(typeof method, "function");
-  }
 });
 
 const cases = [
@@ -63,30 +87,97 @@ const cases = [
 ];
 
 for (const [method, args, expectedPath] of cases) {
-  test(`${method} returns a Promise and requests ${expectedPath}`, async () => {
+  test(`${method} requests ${expectedPath}`, async () => {
     const body = { data: { method } };
     const calls = stubRequest({ body });
     const resultPromise = createWakaTime(API_KEY)[method](...args);
-
     assert.ok(resultPromise instanceof Promise);
     assert.deepEqual(await resultPromise, body);
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].method, "GET");
-    assert.equal(calls[0].hostname, "wakatime.com");
-    assert.equal(calls[0].path, expectedPath);
-    assert.equal(calls[0].headers.Authorization, `Basic ${Buffer.from(API_KEY).toString("base64")}`);
+    assert.equal(calls[0].options.method, "GET");
+    assert.equal(calls[0].options.hostname, "api.wakatime.com");
+    assert.equal(calls[0].options.path, expectedPath);
+    assert.equal(calls[0].options.headers.Authorization, `Basic ${Buffer.from(API_KEY).toString("base64")}`);
+    assert.equal(calls[0].request.timeout, 30000);
   });
 }
 
-test("resolves successful JSON without changing its shape", async () => {
-  const body = { data: { nested: [1, { value: true }] }, meta: { status: "ok" } };
-  stubRequest({ body });
-
-  assert.deepEqual(await createWakaTime(API_KEY).currentUser(), body);
+test("resolves a 202 JSON response without changing its shape", async () => {
+  const body = { data: { is_up_to_date: false } };
+  stubRequest({ statusCode: 202, body });
+  assert.deepEqual(await createWakaTime(API_KEY).lastYear(), body);
 });
 
-test("rejects malformed JSON", async () => {
-  stubRequest({ malformed: true });
+for (const rawBody of ["", "{"]) {
+  test(`rejects a successful response with ${rawBody ? "malformed JSON" : "an empty body"}`, async () => {
+    stubRequest({ rawBody });
+    await assert.rejects(createWakaTime(API_KEY).currentUser(), SyntaxError);
+  });
+}
 
-  await assert.rejects(createWakaTime(API_KEY).currentUser(), SyntaxError);
+for (const statusCode of [301, 400, 401, 403, 404, 429, 500]) {
+  test(`rejects HTTP ${statusCode} with response details`, async () => {
+    const body = { error: `status ${statusCode}` };
+    stubRequest({ statusCode, body });
+    await assert.rejects(createWakaTime(API_KEY).currentUser(), (error) => {
+      assert.equal(error.name, "WakaTimeApiError");
+      assert.equal(error.statusCode, statusCode);
+      assert.equal(error.resource, "/users/current");
+      assert.deepEqual(error.body, body);
+      return true;
+    });
+  });
+}
+
+test("preserves a non-JSON HTTP error body as text", async () => {
+  stubRequest({ statusCode: 500, rawBody: "unavailable" });
+  await assert.rejects(createWakaTime(API_KEY).currentUser(), { body: "unavailable" });
+});
+
+for (const [name, scenario, pattern] of [
+  ["request errors", { requestError: new Error("socket failed") }, /socket failed/],
+  ["response errors", { responseError: new Error("response failed") }, /response failed/],
+  ["aborted responses", { aborted: true }, /aborted/],
+  ["prematurely closed responses", { prematureClose: true }, /closed before completion/],
+]) {
+  test(`rejects ${name}`, async () => {
+    stubRequest(scenario);
+    await assert.rejects(createWakaTime(API_KEY).currentUser(), pattern);
+  });
+}
+
+test("rejects timed out requests", async () => {
+  stubRequest({ timeout: true });
+  await assert.rejects(createWakaTime(API_KEY).currentUser(), (error) => error.code === "ETIMEDOUT");
+});
+
+for (const apiKey of [undefined, null, "", "   ", 123]) {
+  test(`rejects invalid API key ${JSON.stringify(apiKey)} before requesting`, async () => {
+    const calls = stubRequest();
+    const result = createWakaTime(apiKey).currentUser();
+    assert.ok(result instanceof Promise);
+    await assert.rejects(result, /apiKey must be a non-empty string/);
+    assert.equal(calls.length, 0);
+  });
+}
+
+for (const [start, end] of [
+  [undefined, "2020-01-01"],
+  ["2020-01-01", undefined],
+  ["2020-02-30", "2020-03-01"],
+  ["2020-1-01", "2020-01-31"],
+  ["2020-02-01", "2020-01-31"],
+  ["2020-01-01&project=secret", "2020-01-31"],
+]) {
+  test(`rejects invalid summary range ${start} to ${end} before requesting`, async () => {
+    const calls = stubRequest();
+    await assert.rejects(createWakaTime(API_KEY).summaries(start, end), TypeError);
+    assert.equal(calls.length, 0);
+  });
+}
+
+test("accepts leap days and equal summary dates", async () => {
+  const calls = stubRequest();
+  await createWakaTime(API_KEY).summaries("2024-02-29", "2024-02-29");
+  assert.equal(calls[0].options.path, "/api/v1/users/current/summaries?start=2024-02-29&end=2024-02-29");
 });


### PR DESCRIPTION
## Summary

- use the documented `api.wakatime.com` API host and retain the existing CommonJS API
- add strict credential and summary-date validation, URL-safe queries, and a 30-second timeout
- reject HTTP and transport failures with inspectable error details
- cover success, 202, redirects, HTTP errors, malformed and empty responses, connection failures, timeout, abort, premature close, and invalid inputs offline

## Verification

- `npm ci`
- `npm test` (35 tests passed)
- `npx eslint --no-fix index.js example.js test/index.test.js`

Closes #48
Part of #46
