### PR TITLE
Document the supported contract and verify package release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 2.0.0 (Unreleased)
+
+This is a major release because it removes support for end-of-life Node.js versions and changes previously successful HTTP error responses into Promise rejections.
+
+### Changed
+
+- Require a supported Node.js 22 or 24 LTS release.
+- Send requests to the documented `api.wakatime.com` API host.
+- Reject redirects and HTTP error responses with inspectable status, resource, and response-body information.
+- Reject transport failures, aborted responses, premature closes, and requests that exceed the 30-second timeout.
+- Reject missing API keys and invalid summary date ranges before sending a request.
+- Require summary dates to be real `YYYY-MM-DD` calendar dates in chronological order.
+
+### Preserved
+
+- CommonJS consumption.
+- Existing public method names and argument order.
+- API-key Basic authentication.
+- Parsed WakaTime response objects for successful JSON responses, including `202 Accepted`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 70-10
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,52 +1,104 @@
 # wakatime-promise
 
+A small, dependency-free Promise client for the WakaTime API.
+
+## Requirements
+
+- Node.js 22.13 or later in the Node.js 22 LTS line
+- Node.js 24 LTS
+- A secret WakaTime API key
+
+This package is for server-side Node.js applications. Never expose a WakaTime API key in browser code, public client-side JavaScript, URLs, logs, or source control.
+
+## Install
+
+```sh
+npm install wakatime-promise
 ```
-$ npm install wakatime-promise
+
+## Usage
+
+```js
+const wakatime = require("wakatime-promise")(process.env.WAKATIME_API_KEY);
 ```
 
-## example
+Each API method returns a Promise that resolves to the parsed WakaTime JSON response without wrapping or reshaping it.
 
-```javascript
-const wakatime = require("wakatime-promise")("YOUR_API_KEY");
-
-async function main() {
-  const data = await wakatime.last7Days();
-  console.log(JSON.stringify(data, null, 2));
+```js
+async function loadStats(wakatime) {
+  return wakatime.last7Days();
 }
-
-main().catch(console.error);
 ```
 
 ## API
 
 ### `wakatime(apiKey)`
 
-- Type: `string`
-
-waka time api key
+Creates a client using WakaTime HTTP Basic authentication. `apiKey` must be a non-empty string. Invalid keys cause API methods to return a rejected Promise before a request is sent.
 
 ### `wakatime.currentUser()`
 
+Returns the current WakaTime user.
+
 ### `wakatime.last7Days()`
+
+Returns stats for the last seven days.
 
 ### `wakatime.last30Days()`
 
+Returns stats for the last 30 days.
+
 ### `wakatime.last6Months()`
+
+Returns stats for the last six months.
 
 ### `wakatime.lastYear()`
 
+Returns stats for the last year.
+
+WakaTime may respond to a stats request with `202 Accepted` while refreshing stale stats. A 202 JSON response resolves normally; callers can inspect WakaTime's `is_up_to_date` response field and retry when appropriate.
+
 ### `wakatime.summaries(start, end)`
 
-#### `start`
+Returns summaries for an inclusive date range.
 
-- Type: `string`
-- Format: `YYYY-MM-DD`
+- `start`: a real calendar date in `YYYY-MM-DD` format
+- `end`: a real calendar date in `YYYY-MM-DD` format
+- `start` must be earlier than or equal to `end`
 
-start date (exmaple: `2016-06-01`)
+Invalid ranges return a rejected Promise before a request is sent.
 
-#### `end`
+## Errors and timeouts
 
-- Type: `string`
-- Format: `YYYY-MM-DD`
+Requests time out after 30 seconds. DNS, TLS, socket, aborted-response, premature-close, timeout, empty-response, and invalid-JSON failures reject the Promise.
 
-end date (exmaple: `2016-06-01`)
+Redirects and HTTP error statuses reject with an `Error` whose `name` is `WakaTimeApiError`. The error has these inspectable properties:
+
+- `statusCode`: the HTTP status code
+- `resource`: the requested WakaTime API resource
+- `body`: the parsed JSON error body, the raw response text when it is not JSON, or `null` for an empty body
+
+```js
+async function loadCurrentUser(wakatime) {
+  try {
+    return await wakatime.currentUser();
+  } catch (error) {
+    if (error.name === "WakaTimeApiError") {
+      console.error(error.statusCode, error.resource, error.body);
+    }
+    throw error;
+  }
+}
+```
+
+Transport timeout errors have `code` set to `ETIMEDOUT`. API keys are never included in request URLs or generated error messages.
+
+## Development
+
+```sh
+npm ci
+npm run check
+npm pack --dry-run
+```
+
+Tests use synthetic credentials and mocked HTTPS requests. They do not contact WakaTime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wakatime-promise",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wakatime-promise",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,26 @@
 {
   "name": "wakatime-promise",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "WakaTime API for Promise",
   "keywords": [],
   "homepage": "https://github.com/70-10/wakatime-promise",
   "repository": "70-10/wakatime-promise",
   "license": "MIT",
   "main": "index.js",
+  "files": [
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md",
+    "index.js"
+  ],
   "scripts": {
     "audit": "npm audit --audit-level=high",
-    "check": "npm run lint && npm run format:check && npm test && npm run audit",
+    "check": "npm run lint && npm run format:check && npm test && npm run package:check && npm run audit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
+    "package:check": "node scripts/verify-package.js",
     "test": "node --test"
   },
   "devDependencies": {

--- a/scripts/verify-package.js
+++ b/scripts/verify-package.js
@@ -1,0 +1,42 @@
+const assert = require("assert").strict;
+const { execFileSync } = require("child_process");
+const { mkdtempSync, mkdirSync, rmSync, writeFileSync } = require("fs");
+const { createRequire } = require("module");
+const { tmpdir } = require("os");
+const path = require("path");
+
+const expectedFiles = ["CHANGELOG.md", "LICENSE", "README.md", "index.js", "package.json"];
+const temporaryRoot = mkdtempSync(path.join(tmpdir(), "wakatime-promise-package-"));
+
+try {
+  const packOutput = execFileSync("npm", ["pack", "--json", "--pack-destination", temporaryRoot], {
+    cwd: path.resolve(__dirname, ".."),
+    encoding: "utf8",
+  });
+  const [packResult] = JSON.parse(packOutput);
+  assert.deepEqual(packResult.files.map(({ path: filePath }) => filePath).sort(), expectedFiles);
+
+  const consumerDirectory = path.join(temporaryRoot, "consumer");
+  mkdirSync(consumerDirectory);
+  writeFileSync(path.join(consumerDirectory, "package.json"), '{"private":true}');
+  const tarball = path.join(temporaryRoot, packResult.filename);
+  execFileSync("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund", tarball], {
+    cwd: consumerDirectory,
+    stdio: "pipe",
+  });
+
+  const consumerRequire = createRequire(path.join(consumerDirectory, "index.js"));
+  const createWakaTime = consumerRequire("wakatime-promise");
+  const client = createWakaTime("synthetic-api-key");
+  assert.deepEqual(Object.keys(client).sort(), [
+    "currentUser",
+    "last30Days",
+    "last6Months",
+    "last7Days",
+    "lastYear",
+    "summaries",
+  ]);
+  console.log(`Verified package contents and CommonJS API for ${packResult.filename}`);
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- document the complete server-side API, failure contract, timeout, security guidance, and Node.js support policy
- add the approved MIT license and 2.0.0 unreleased changelog
- restrict package contents to five consumer files
- verify the generated tarball through a clean temporary install and CommonJS API smoke test

## Verification

- `npm ci`
- `npm run check` (35 tests passed, package install verified, audit clean)
- `npm pack --dry-run` (5 expected files)

Closes #50
Part of #46
